### PR TITLE
Initial PR for a package API usage analysis tool

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,30 @@
+name: Dart CI
+
+on:
+  schedule:
+    # “At 00:00 (UTC) on Sunday.”
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+
+      - name: Install dependencies
+        run: dart pub get
+  
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze project source
+        run: dart analyze --fatal-infos
+
+      - name: Run tests
+        run: dart test

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub.
 .dart_tool/
 .packages
+pubspec.lock
 
 # Conventional directory for build output.
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+- Initial version.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,40 @@
+## What's this?
+
+This is a tool to calculate the API usage for a package - what part's of a
+package's API are typically used by other Dart packages and applications.
+
+It is run from the command line:
+
+```
+dart bin/api_usage.dart <package-name>
+```
+
+It queries pub.dev for the packages that use `<package-name>`, downloads the
+referencing packages, analyzes them, and determines which portions of the target
+package's API are used. For an example usage report, see
+[collection.md](doc/collection.md).
+
+## Usage
+
+To use this tool, clone the repo, and run:
+
+```
+dart bin/api_usage.dart <package-name>
+```
+
+Some available options are:
+
+- `--package-limit`: limit the number of packages that are used for analysis
+  (this defaults to all referencing packages on pub.dev), 
+- `--show-src-references`: when there are references into a packages `lib/src/`
+  directory (something that's generally not intended to be part of a package's
+  public API), this option we include which package is using the src/ library
+
+```
+usage: dart bin/api_usage.dart [options] <package-name>
+
+options:
+-h, --help                     Print this usage information.
+    --package-limit=<count>    Limit the number of packages usage data is collected from.
+    --show-src-references      Report specific references to src/ libraries.
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## What's this?
 
-This is a tool to calculate the API usage for a package - what part's of a
+This is a tool to calculate the API usage for a package - what parts of a
 package's API are typically used by other Dart packages and applications.
 
 It is run from the command line:
@@ -26,9 +26,10 @@ Some available options are:
 
 - `--package-limit`: limit the number of packages that are used for analysis
   (this defaults to all referencing packages on pub.dev), 
-- `--show-src-references`: when there are references into a packages `lib/src/`
+- `--show-src-references`: when there are references into a package's `lib/src/`
   directory (something that's generally not intended to be part of a package's
-  public API), this option we include which package is using the src/ library
+  public API), this option will include which package is using the `src/`
+  library in the output
 
 ```
 usage: dart bin/api_usage.dart [options] <package-name>

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - cache/**

--- a/bin/api_usage.dart
+++ b/bin/api_usage.dart
@@ -1,0 +1,164 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:cli_util/cli_logging.dart';
+import 'package:corpus/api.dart';
+import 'package:corpus/cache.dart';
+import 'package:corpus/packages.dart';
+import 'package:corpus/pub.dart';
+import 'package:corpus/report.dart';
+import 'package:path/path.dart' as path;
+import 'package:surveyor/src/driver.dart';
+
+void main(List<String> args) async {
+  var argParser = createArgParser();
+
+  late ArgResults argResults;
+  try {
+    argResults = argParser.parse(args);
+  } on FormatException catch (e) {
+    print(e.message);
+    print('');
+    printUsage(argParser);
+    exit(64);
+  }
+
+  if (argResults.rest.length != 1 || argResults['help']) {
+    printUsage(argParser);
+    exit(1);
+  }
+
+  final packageName = argResults.rest.first;
+  String? packageLimit = argResults['package-limit'];
+  bool showSrcReferences = argResults['show-src-references'] as bool;
+
+  var log = Logger.standard();
+
+  log.stdout('API usage analysis for package:$packageName.');
+  log.stdout('');
+
+  var pub = Pub();
+  var packageManager = PackageManager();
+
+  var progress = log.progress('querying pub.dev');
+
+  var targetPackage = await pub.getPackageInfo(packageName);
+
+  var packages = await pub.popularDependenciesOf(
+    packageName,
+    limit: packageLimit == null ? null : int.parse(packageLimit),
+    filter: (PackageInfo packageInfo) {
+      // Only use packages which have been updated in the last year.
+      return packageInfo.publishedDate.isAfter(
+        DateTime.now().subtract(Duration(days: 365)),
+      );
+    },
+  );
+
+  progress.finish(message: 'found ${packages.length} packages');
+
+  List<ApiUsage> usageInfo = [];
+
+  for (var packageInfo in packages) {
+    log.stdout('');
+    log.stdout('${packageInfo.name} v${packageInfo.version}');
+
+    bool downloadSuccess =
+        await packageManager.retrievePackageArchive(packageInfo, logger: log);
+    if (!downloadSuccess) {
+      log.stdout('error downloading ${packageInfo.archiveUrl}');
+      continue;
+    }
+
+    var localPackage = await packageManager.rehydratePackage(packageInfo);
+
+    var pubSuccess =
+        await localPackage.pubGet(checkUpToDate: true, logger: log);
+    if (!pubSuccess) {
+      continue;
+    }
+
+    progress = log.progress('analyzing package');
+    var usage = await analyzePackage(
+        targetPackage, packageInfo, localPackage.directory);
+    progress.finish(message: usage.describeUsage());
+
+    usageInfo.add(usage);
+  }
+
+  var report = Report(targetPackage);
+  var file = report.generateReport(
+    usageInfo,
+    showSrcReferences: showSrcReferences,
+  );
+
+  log.stdout('');
+  log.stdout('wrote ${file.path}.');
+
+  packageManager.close();
+
+  pub.close();
+}
+
+ArgParser createArgParser() {
+  var parser = ArgParser();
+  parser.addFlag(
+    'help',
+    abbr: 'h',
+    negatable: false,
+    help: 'Print this usage information.',
+  );
+  parser.addOption(
+    'package-limit',
+    help: 'Limit the number of packages usage data is collected from.',
+    valueHelp: 'count',
+  );
+  parser.addFlag(
+    'show-src-references',
+    negatable: false,
+    help: 'Report specific references to src/ libraries.',
+  );
+  return parser;
+}
+
+void printUsage(ArgParser argParser) {
+  print('usage: dart bin/api_usage.dart [options] <package-name>');
+  print('');
+  print('options:');
+  print(argParser.usage);
+}
+
+Future<ApiUsage> analyzePackage(
+  PackageInfo targetPackage,
+  PackageInfo usingPackage,
+  Directory usingPackageDir,
+) async {
+  var cache = Cache();
+  var file = File(path.join(
+    cache.usageDir.path,
+    '${targetPackage.name}-${targetPackage.version}',
+    '${usingPackage.name}-${usingPackage.version}.json',
+  ));
+
+  if (file.existsSync()) {
+    ApiUsage usage = ApiUsage.fromFile(usingPackage, file);
+    return usage;
+  }
+
+  var apiUsageCollector =
+      ApiUseCollector(targetPackage, usingPackage, usingPackageDir);
+
+  var driver = Driver.forArgs([usingPackageDir.path]);
+  driver.forceSkipInstall = true;
+  driver.silent = true;
+  driver.showErrors = false;
+  driver.resolveUnits = true;
+  driver.excludedPaths = ['example'];
+  driver.visitor = apiUsageCollector;
+
+  await driver.analyze();
+  var usage = apiUsageCollector.usage;
+  file.parent.createSync();
+  usage.toFile(file);
+  return usage;
+}

--- a/bin/api_usage.dart
+++ b/bin/api_usage.dart
@@ -44,14 +44,14 @@ void main(List<String> args) async {
 
   var targetPackage = await pub.getPackageInfo(packageName);
 
+  final dateOneYearAgo = DateTime.now().subtract(Duration(days: 365));
+
   var packages = await pub.popularDependenciesOf(
     packageName,
     limit: packageLimit == null ? null : int.parse(packageLimit),
     filter: (PackageInfo packageInfo) {
       // Only use packages which have been updated in the last year.
-      return packageInfo.publishedDate.isAfter(
-        DateTime.now().subtract(Duration(days: 365)),
-      );
+      return packageInfo.publishedDate.isAfter(dateOneYearAgo);
     },
   );
 

--- a/doc/collection.md
+++ b/doc/collection.md
@@ -1,0 +1,171 @@
+# Report for package:collection
+
+## General info
+
+Collections and utilities functions and classes related to collections.
+
+- pub page: https://pub.dev/packages/collection
+- docs: https://pub.dev/documentation/collection/latest/
+- dependent packages: https://pub.dev/packages?q=dependency%3Acollection&sort=top
+
+Stats for collection v1.16.0 pulled from 101 packages.
+
+## Library references
+
+### Library references from packages
+
+- package:collection/collection.dart - 94 package references (93%)
+- package:collection/src/iterable_extensions.dart - 1 package reference (1%)
+
+### Library references from libraries
+
+- package:collection/collection.dart - 293 library references (95%)
+- package:collection/src/iterable_extensions.dart - 1 library reference (0%)
+
+## Class references
+
+### Class references from packages
+
+- ListEquality - 26 package references (26%)
+- DeepCollectionEquality - 19 package references (19%)
+- MapEquality - 12 package references (12%)
+- SetEquality - 5 package references (5%)
+- QueueList - 4 package references (4%)
+- IterableEquality - 4 package references (4%)
+- DelegatingList - 3 package references (3%)
+- UnmodifiableSetView - 3 package references (3%)
+- UnorderedIterableEquality - 2 package references (2%)
+- CanonicalizedMap - 2 package references (2%)
+- DefaultEquality - 2 package references (2%)
+- PriorityQueue - 2 package references (2%)
+- Equality - 2 package references (2%)
+- UnmodifiableMapMixin - 1 package reference (1%)
+- HeapPriorityQueue - 1 package reference (1%)
+- EqualitySet - 1 package reference (1%)
+- IdentityEquality - 1 package reference (1%)
+- NonGrowableListMixin - 1 package reference (1%)
+
+### Class references from libraries
+
+- ListEquality - 52 library references (17%)
+- DeepCollectionEquality - 41 library references (13%)
+- MapEquality - 37 library references (12%)
+- SetEquality - 8 library references (3%)
+- DelegatingList - 5 library references (2%)
+- CanonicalizedMap - 5 library references (2%)
+- QueueList - 4 library references (1%)
+- IterableEquality - 4 library references (1%)
+- UnmodifiableSetView - 4 library references (1%)
+- UnmodifiableMapMixin - 2 library references (1%)
+- UnorderedIterableEquality - 2 library references (1%)
+- DefaultEquality - 2 library references (1%)
+- PriorityQueue - 2 library references (1%)
+- Equality - 2 library references (1%)
+- HeapPriorityQueue - 1 library reference (0%)
+- EqualitySet - 1 library reference (0%)
+- IdentityEquality - 1 library reference (0%)
+- NonGrowableListMixin - 1 library reference (0%)
+
+## Corpus packages
+
+- provider v6.0.3
+- cloud_firestore v3.4.3
+- flutter_riverpod v1.0.4
+- built_value v8.4.0
+- simple_animations v4.2.0
+- go_router v4.2.7
+- flutter_form_builder v7.5.0
+- flutter_map v2.2.0
+- responsive_framework v0.2.0
+- xml v6.1.0
+- stacked v2.3.15
+- better_player v0.0.83
+- hooks_riverpod v1.0.4
+- yaml v3.1.1
+- mocktail v0.3.0
+- adaptive_dialog v1.8.0
+- syncfusion_flutter_datagrid v20.2.40
+- hydrated_bloc v8.1.0
+- http_parser v4.0.1
+- objectbox v1.6.0
+- flutter_quill v5.4.1
+- palette_generator v0.3.3+1
+- dartx v1.1.0
+- sentry v6.9.0
+- process_run v0.12.3+2
+- flutter_portal v1.1.1
+- mapbox_gl v0.16.0
+- flutter_layout_grid v2.0.1
+- web3dart v2.4.1
+- moor v4.6.1+1
+- mason v0.1.0-dev.31
+- routemaster v1.0.1
+- pub_semver v2.1.1
+- pluto_grid v5.0.4
+- adobe_xd v2.0.1
+- flutter_background_geolocation v4.7.0
+- flex_color_picker v2.5.0
+- code_builder v4.2.0
+- telephony v0.2.0
+- storybook_flutter v0.11.1
+- intercom_flutter v7.3.0
+- waterfall_flow v3.0.2
+- spider v4.0.0
+- wiredash v1.1.0
+- graphs v2.1.0
+- signalr_netcore v1.3.1
+- rx_shared_preferences v3.0.0
+- flutter_gen_runner v4.3.0
+- puppeteer v2.12.0
+- fast_i18n v5.12.6
+- dart_ping v7.0.1
+- drag_select_grid_view v0.6.1
+- jovial_svg v1.1.5
+- dcli v1.33.0
+- stream_chat_flutter_core v4.4.1
+- flutter_slidable v2.0.0
+- form_bloc v0.30.0
+- flutter_google_places_hoc081098 v1.1.0
+- enough_mail v2.1.1
+- flutter_cache_manager v3.3.0
+- scrollable_positioned_list v0.3.2
+- dart_code_metrics v4.17.0
+- syncfusion_flutter_datagrid_export v20.2.40-beta
+- firebase_dart v1.0.10+1
+- mobx v2.0.7+5
+- encrypt v5.0.1
+- device_preview v1.1.0
+- shelf v1.3.2
+- introduction_screen v3.0.2
+- async v2.9.0
+- mockito v5.3.0
+- rive v0.9.1
+- test v1.21.4
+- freezed_annotation v2.1.0
+- contacts_service v0.6.3
+- new_version v0.3.1
+- optional v6.1.0+1
+- drift v1.7.1
+- riverpod v1.0.3
+- graphql v5.1.1
+- dropdown_textfield v1.0.3
+- loading_indicator v3.1.0
+- flutter_map_tile_caching v5.0.0
+- flutter_multi_formatter v2.5.8
+- slang v2.6.2
+- bdd_widget_test v1.4.2
+- gql_dio_link v0.2.2
+- protobuf v2.1.0
+- list_ext v1.0.4
+- gpx v2.2.0
+- widget_mask v1.0.0+0
+- back_button_interceptor v6.0.1
+- supercharged_dart v2.1.1
+- flutter_instagram_stories v1.0.2
+- fuzzywuzzy v0.2.0
+- markdown v5.0.0
+- black_hole_flutter v0.3.5
+- country_picker v2.0.15
+- mysql1 v0.20.0
+- youtube_explode_dart v1.12.0
+- more v3.7.1

--- a/doc/collection.md
+++ b/doc/collection.md
@@ -14,106 +14,110 @@ Stats for collection v1.16.0 pulled from 101 packages.
 
 ### Library references from packages
 
-- package:collection/collection.dart - 94 package references (93%)
-- package:collection/src/iterable_extensions.dart - 1 package reference (1%)
+| Library | Package references | % |
+| --- | ---: | ---: |
+| package:collection/collection.dart | 95 | 94% |
+| package:collection/src/iterable_extensions.dart | 1 | 1% |
 
 ### Library references from libraries
 
-- package:collection/collection.dart - 293 library references (95%)
-- package:collection/src/iterable_extensions.dart - 1 library reference (0%)
+| Library | Library references | % |
+| --- | ---: | ---: |
+| package:collection/collection.dart | 296 | 96% |
+| package:collection/src/iterable_extensions.dart | 1 | 0% |
 
 ## Class references
 
 ### Class references from packages
 
-- ListEquality - 26 package references (26%)
-- DeepCollectionEquality - 19 package references (19%)
-- MapEquality - 12 package references (12%)
-- SetEquality - 5 package references (5%)
-- QueueList - 4 package references (4%)
-- IterableEquality - 4 package references (4%)
-- DelegatingList - 3 package references (3%)
-- UnmodifiableSetView - 3 package references (3%)
-- UnorderedIterableEquality - 2 package references (2%)
-- CanonicalizedMap - 2 package references (2%)
-- DefaultEquality - 2 package references (2%)
-- PriorityQueue - 2 package references (2%)
-- Equality - 2 package references (2%)
-- UnmodifiableMapMixin - 1 package reference (1%)
-- HeapPriorityQueue - 1 package reference (1%)
-- EqualitySet - 1 package reference (1%)
-- IdentityEquality - 1 package reference (1%)
-- NonGrowableListMixin - 1 package reference (1%)
+| Class | Package references | % |
+| --- | ---: | ---: |
+| ListEquality | 26 | 26% |
+| DeepCollectionEquality | 20 | 20% |
+| MapEquality | 11 | 11% |
+| SetEquality | 5 | 5% |
+| QueueList | 4 | 4% |
+| IterableEquality | 4 | 4% |
+| DelegatingList | 3 | 3% |
+| UnmodifiableSetView | 3 | 3% |
+| Equality | 3 | 3% |
+| UnorderedIterableEquality | 2 | 2% |
+| CanonicalizedMap | 2 | 2% |
+| DefaultEquality | 2 | 2% |
+| PriorityQueue | 2 | 2% |
+| UnmodifiableMapMixin | 1 | 1% |
+| HeapPriorityQueue | 1 | 1% |
+| EqualitySet | 1 | 1% |
+| IdentityEquality | 1 | 1% |
+| NonGrowableListMixin | 1 | 1% |
 
 ### Class references from libraries
 
-- ListEquality - 52 library references (17%)
-- DeepCollectionEquality - 41 library references (13%)
-- MapEquality - 37 library references (12%)
-- SetEquality - 8 library references (3%)
-- DelegatingList - 5 library references (2%)
-- CanonicalizedMap - 5 library references (2%)
-- QueueList - 4 library references (1%)
-- IterableEquality - 4 library references (1%)
-- UnmodifiableSetView - 4 library references (1%)
-- UnmodifiableMapMixin - 2 library references (1%)
-- UnorderedIterableEquality - 2 library references (1%)
-- DefaultEquality - 2 library references (1%)
-- PriorityQueue - 2 library references (1%)
-- Equality - 2 library references (1%)
-- HeapPriorityQueue - 1 library reference (0%)
-- EqualitySet - 1 library reference (0%)
-- IdentityEquality - 1 library reference (0%)
-- NonGrowableListMixin - 1 library reference (0%)
+| Class | Library references | % |
+| --- | ---: | ---: |
+| ListEquality | 50 | 16% 
+| DeepCollectionEquality | 42 | 14% 
+| MapEquality | 36 | 12% 
+| SetEquality | 8 | 3% 
+| DelegatingList | 5 | 2% 
+| CanonicalizedMap | 5 | 2% 
+| QueueList | 4 | 1% 
+| IterableEquality | 4 | 1% 
+| UnmodifiableSetView | 4 | 1% 
+| Equality | 3 | 1% 
+| UnmodifiableMapMixin | 2 | 1% 
+| UnorderedIterableEquality | 2 | 1% 
+| DefaultEquality | 2 | 1% 
+| PriorityQueue | 2 | 1% 
+| HeapPriorityQueue | 1 | 0% 
+| EqualitySet | 1 | 0% 
+| IdentityEquality | 1 | 0% 
+| NonGrowableListMixin | 1 | 0% 
 
 ## Corpus packages
 
 - provider v6.0.3
-- cloud_firestore v3.4.3
-- flutter_riverpod v1.0.4
 - built_value v8.4.0
-- simple_animations v4.2.0
 - go_router v4.2.7
+- simple_animations v5.0.0+2
 - flutter_form_builder v7.5.0
 - flutter_map v2.2.0
 - responsive_framework v0.2.0
 - xml v6.1.0
-- stacked v2.3.15
-- better_player v0.0.83
 - hooks_riverpod v1.0.4
+- better_player v0.0.83
 - yaml v3.1.1
 - mocktail v0.3.0
 - adaptive_dialog v1.8.0
-- syncfusion_flutter_datagrid v20.2.40
-- hydrated_bloc v8.1.0
+- syncfusion_flutter_datagrid v20.2.43
 - http_parser v4.0.1
-- objectbox v1.6.0
 - flutter_quill v5.4.1
+- objectbox v1.6.0
+- flutter_multi_formatter v2.6.0
 - palette_generator v0.3.3+1
 - dartx v1.1.0
 - sentry v6.9.0
 - process_run v0.12.3+2
-- flutter_portal v1.1.1
-- mapbox_gl v0.16.0
 - flutter_layout_grid v2.0.1
-- web3dart v2.4.1
-- moor v4.6.1+1
+- mapbox_gl v0.16.0
+- flutter_portal v1.1.1
 - mason v0.1.0-dev.31
+- web3dart v2.4.1
 - routemaster v1.0.1
 - pub_semver v2.1.1
-- pluto_grid v5.0.4
 - adobe_xd v2.0.1
-- flutter_background_geolocation v4.7.0
+- pluto_grid v5.0.4
+- flutter_background_geolocation v4.7.1
 - flex_color_picker v2.5.0
 - code_builder v4.2.0
 - telephony v0.2.0
 - storybook_flutter v0.11.1
-- intercom_flutter v7.3.0
 - waterfall_flow v3.0.2
 - spider v4.0.0
+- dart_json_mapper v2.2.5+2
 - wiredash v1.1.0
 - graphs v2.1.0
-- signalr_netcore v1.3.1
+- signalr_netcore v1.3.2
 - rx_shared_preferences v3.0.0
 - flutter_gen_runner v4.3.0
 - puppeteer v2.12.0
@@ -123,49 +127,53 @@ Stats for collection v1.16.0 pulled from 101 packages.
 - jovial_svg v1.1.5
 - dcli v1.33.0
 - stream_chat_flutter_core v4.4.1
+- cloud_firestore v3.4.4
 - flutter_slidable v2.0.0
-- form_bloc v0.30.0
 - flutter_google_places_hoc081098 v1.1.0
 - enough_mail v2.1.1
-- flutter_cache_manager v3.3.0
-- scrollable_positioned_list v0.3.2
-- dart_code_metrics v4.17.0
-- syncfusion_flutter_datagrid_export v20.2.40-beta
+- form_bloc v0.30.0
 - firebase_dart v1.0.10+1
+- flutter_riverpod v1.0.4
+- dart_code_metrics v4.17.0
+- scrollable_positioned_list v0.3.2
+- syncfusion_flutter_datagrid_export v20.2.43-beta
+- split_view v3.2.1
 - mobx v2.0.7+5
-- encrypt v5.0.1
-- device_preview v1.1.0
-- shelf v1.3.2
 - introduction_screen v3.0.2
+- shelf v1.3.2
+- device_preview v1.1.0
 - async v2.9.0
 - mockito v5.3.0
+- elementary v1.5.0
 - rive v0.9.1
 - test v1.21.4
+- dropdown_textfield v1.0.3
+- stacked v2.3.15
 - freezed_annotation v2.1.0
 - contacts_service v0.6.3
-- new_version v0.3.1
+- flutter_map_tile_caching v5.1.1
 - optional v6.1.0+1
-- drift v1.7.1
 - riverpod v1.0.3
+- hydrated_bloc v8.1.0
 - graphql v5.1.1
-- dropdown_textfield v1.0.3
 - loading_indicator v3.1.0
-- flutter_map_tile_caching v5.0.0
-- flutter_multi_formatter v2.5.8
-- slang v2.6.2
-- bdd_widget_test v1.4.2
-- gql_dio_link v0.2.2
-- protobuf v2.1.0
-- list_ext v1.0.4
-- gpx v2.2.0
+- slang v2.7.0
 - widget_mask v1.0.0+0
-- back_button_interceptor v6.0.1
+- protobuf v2.1.0
+- bdd_widget_test v1.4.2
+- list_ext v1.0.4
+- gql_dio_link v0.2.3
+- swagger_dart_code_generator v2.7.3
 - supercharged_dart v2.1.1
-- flutter_instagram_stories v1.0.2
+- back_button_interceptor v6.0.1
+- gpx v2.2.0
 - fuzzywuzzy v0.2.0
-- markdown v5.0.0
-- black_hole_flutter v0.3.5
+- flutter_instagram_stories v1.0.2
+- markdown v6.0.0
 - country_picker v2.0.15
-- mysql1 v0.20.0
 - youtube_explode_dart v1.12.0
+- mysql1 v0.20.0
+- cryptography v2.0.5
+- black_hole_flutter v0.3.5
 - more v3.7.1
+- alice v0.2.5

--- a/lib/api.dart
+++ b/lib/api.dart
@@ -1,0 +1,380 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:path/path.dart' as path;
+// ignore: implementation_imports
+import 'package:surveyor/src/visitors.dart';
+
+import 'pub.dart';
+import 'utils.dart';
+
+// todo: report extension method usage
+
+class ApiUsage {
+  final PackageInfo package;
+
+  final References fromPackages;
+  final References fromLibraries;
+
+  ApiUsage(this.package, this.fromPackages, this.fromLibraries);
+
+  static CollectedApiUsage combine(
+    PackageInfo targetPackage,
+    List<ApiUsage> usages,
+  ) {
+    var corpusPackages = <PackageInfo>[];
+
+    var referringPackages = References();
+    var referringLibraries = References();
+
+    for (var usage in usages) {
+      corpusPackages.add(usage.package);
+
+      referringPackages.combineWith(usage.fromPackages);
+      referringLibraries.combineWith(usage.fromLibraries);
+    }
+
+    return CollectedApiUsage(
+      targetPackage,
+      corpusPackages,
+      referringPackages,
+      referringLibraries,
+    );
+  }
+
+  void toFile(File file) {
+    Map json = {
+      'packages': fromPackages.toJson(),
+      'libraries': fromLibraries.toJson(),
+    };
+    file.writeAsStringSync(JsonEncoder.withIndent('  ').convert(json));
+  }
+
+  String describeUsage() {
+    int libraryCount = fromPackages.sortedLibraryReferences.length;
+    int classCount = fromPackages.sortedClassReferences.length;
+    int symbolCount = fromPackages.sortedTopLevelReferences.length;
+    return 'referenced $libraryCount ${pluralize(libraryCount, 'library', plural: 'libraries')}, '
+        '$classCount ${pluralize(classCount, 'class', plural: 'classes')}, '
+        'and $symbolCount top-level ${pluralize(symbolCount, 'symbol')}';
+  }
+
+  static ApiUsage fromFile(PackageInfo packageInfo, File file) {
+    var json =
+        JsonDecoder().convert(file.readAsStringSync()) as Map<String, dynamic>;
+    return ApiUsage(
+      packageInfo,
+      References.fromJson(json['packages']),
+      References.fromJson(json['libraries']),
+    );
+  }
+}
+
+class CollectedApiUsage {
+  final PackageInfo targetPackage;
+
+  final List<PackageInfo> corpusPackages;
+
+  final References referringPackages;
+  final References referringLibraries;
+
+  CollectedApiUsage(
+    this.targetPackage,
+    this.corpusPackages,
+    this.referringPackages,
+    this.referringLibraries,
+  );
+}
+
+class ApiUseCollector extends RecursiveAstVisitor implements AstContext {
+  final PackageInfo targetPackage;
+  final PackageInfo usingPackage;
+  final Directory usingPackageDir;
+  late PackageEntity usingPackageEntity;
+
+  References referringPackages = References();
+  References referringLibraries = References();
+
+  String? _currentFilePath;
+
+  ApiUseCollector(this.targetPackage, this.usingPackage, this.usingPackageDir) {
+    usingPackageEntity = PackageEntity(usingPackage.name);
+  }
+
+  String get targetName => targetPackage.name;
+
+  ApiUsage get usage =>
+      ApiUsage(usingPackage, referringPackages, referringLibraries);
+
+  String get currentPackage => usage.package.name;
+
+  @override
+  void setFilePath(String filePath) {
+    _currentFilePath = filePath;
+  }
+
+  @override
+  void setLineInfo(LineInfo lineInfo) {}
+
+  @override
+  void visitImportDirective(ImportDirective node) {
+    var uri = node.uriContent;
+
+    if (uri != null && uri.startsWith('package:')) {
+      if (uri.startsWith('package:$targetName/')) {
+        referringPackages.addLibraryReference(uri, usingPackageEntity);
+        var relativeLibraryPath =
+            path.relative(_currentFilePath!, from: usingPackageDir.path);
+        referringLibraries.addLibraryReference(
+            uri, LibraryEntity(currentPackage, relativeLibraryPath));
+      }
+    }
+
+    super.visitImportDirective(node);
+  }
+
+  @override
+  void visitNamedType(NamedType node) {
+    super.visitNamedType(node);
+
+    _handleType(node.type);
+  }
+
+  @override
+  void visitSimpleIdentifier(SimpleIdentifier node) {
+    super.visitSimpleIdentifier(node);
+
+    var element = node.staticElement;
+    if (element != null && element.kind == ElementKind.GETTER) {
+      // We only want library getters.
+      if (element.enclosingElement!.kind != ElementKind.COMPILATION_UNIT) {
+        return;
+      }
+
+      var library = element.library;
+      if (library == null || library.isInSdk) {
+        return;
+      }
+
+      var libraryUri = library.librarySource.uri;
+      if (libraryUri.scheme == 'package' &&
+          libraryUri.pathSegments.first == targetName) {
+        referringPackages.addTopLevelReference(
+            element.name!, usingPackageEntity);
+        var relativeLibraryPath =
+            path.relative(_currentFilePath!, from: usingPackageDir.path);
+        referringLibraries.addTopLevelReference(
+            element.name!, LibraryEntity(currentPackage, relativeLibraryPath));
+      }
+    }
+  }
+
+  // @override
+  // visitMethodInvocation(MethodInvocation node) {
+  //   return super.visitMethodInvocation(node);
+
+  //   // todo:
+  // }
+
+  void _handleType(DartType? type) {
+    var element = type?.element;
+    if (element != null) {
+      var library = element.library;
+      if (library == null || library.isInSdk) {
+        return;
+      }
+
+      var libraryUri = library.librarySource.uri;
+      if (libraryUri.scheme == 'package' &&
+          libraryUri.pathSegments.first == targetName) {
+        referringPackages.addClassReference(element.name!, usingPackageEntity);
+        var relativeLibraryPath =
+            path.relative(_currentFilePath!, from: usingPackageDir.path);
+        referringLibraries.addClassReference(
+            element.name!, LibraryEntity(currentPackage, relativeLibraryPath));
+      }
+    }
+  }
+}
+
+/// A referring entity - either a package or a library.
+abstract class Entity {
+  String toJson();
+
+  static Entity fromJson(String json) {
+    List l = json.split(':');
+    if (l.first == 'package') {
+      return PackageEntity(l[1]);
+    } else {
+      return LibraryEntity(l[1], l[2]);
+    }
+  }
+}
+
+class PackageEntity extends Entity {
+  final String name;
+
+  PackageEntity(this.name);
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is PackageEntity && name == other.name;
+  }
+
+  @override
+  String toJson() => 'package:$name';
+
+  @override
+  String toString() => 'package:$name';
+}
+
+class LibraryEntity extends Entity {
+  final String package;
+  final String libraryPath;
+
+  LibraryEntity(this.package, this.libraryPath);
+
+  @override
+  int get hashCode => package.hashCode ^ libraryPath.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is LibraryEntity &&
+        package == other.package &&
+        libraryPath == other.libraryPath;
+  }
+
+  @override
+  String toJson() => 'library:$package:$libraryPath';
+
+  @override
+  String toString() => 'package:$package/$libraryPath';
+}
+
+class References {
+  final EntityReferences _libraryReferences = EntityReferences();
+  final EntityReferences _classReferences = EntityReferences();
+  final EntityReferences _topLevelReferences = EntityReferences();
+
+  References();
+
+  factory References.fromJson(Map<String, dynamic> json) {
+    var refs = References();
+
+    refs._libraryReferences.fromJson(json['library']);
+    refs._classReferences.fromJson(json['class']);
+    refs._topLevelReferences.fromJson(json['topLevel']);
+
+    return refs;
+  }
+
+  Set<Entity> get allEntities {
+    var result = <Entity>{};
+
+    result.addAll(_libraryReferences.entities);
+    result.addAll(_classReferences.entities);
+    result.addAll(_topLevelReferences.entities);
+
+    return result;
+  }
+
+  int get entityCount => allEntities.length;
+
+  void addLibraryReference(String ref, Entity entity) {
+    _libraryReferences.add(ref, entity);
+  }
+
+  void addClassReference(String ref, Entity entity) {
+    _classReferences.add(ref, entity);
+  }
+
+  void addTopLevelReference(String ref, Entity entity) {
+    _topLevelReferences.add(ref, entity);
+  }
+
+  Set<Entity> getLibraryReferences(String ref) {
+    return _libraryReferences._references[ref]!;
+  }
+
+  Map<String, int> get sortedLibraryReferences =>
+      _libraryReferences.sortedReferences;
+
+  Map<String, int> get sortedClassReferences =>
+      _classReferences.sortedReferences;
+
+  Map<String, int> get sortedTopLevelReferences =>
+      _topLevelReferences.sortedReferences;
+
+  void combineWith(References references) {
+    _libraryReferences.combineWith(references._libraryReferences);
+    _classReferences.combineWith(references._classReferences);
+    _topLevelReferences.combineWith(references._topLevelReferences);
+  }
+
+  Map toJson() {
+    return {
+      'library': _libraryReferences.toJson(),
+      'class': _classReferences.toJson(),
+      'topLevel': _topLevelReferences.toJson(),
+    };
+  }
+}
+
+class EntityReferences {
+  final Map<String, Set<Entity>> _references = {};
+
+  EntityReferences();
+
+  Set<Entity> get entities {
+    var result = <Entity>{};
+    for (var key in _references.keys) {
+      result.addAll(_references[key]!);
+    }
+    return result;
+  }
+
+  void add(String ref, Entity entity) {
+    _references.putIfAbsent(ref, () => {});
+    _references[ref]!.add(entity);
+  }
+
+  Map<String, int> get sortedReferences => _sortByCount(_references);
+
+  Map<String, int> _sortByCount(Map<String, Set<Entity>> refs) {
+    List<String> keys = refs.keys.toList();
+    keys.sort((a, b) => refs[b]!.length - refs[a]!.length);
+    return Map.fromIterable(keys, value: (key) => refs[key]!.length);
+  }
+
+  void combineWith(EntityReferences other) {
+    for (var entry in other._references.entries) {
+      for (var entity in entry.value) {
+        add(entry.key, entity);
+      }
+    }
+  }
+
+  void fromJson(Map json) {
+    for (var key in json.keys) {
+      List entities = json[key];
+      for (var entity in entities) {
+        add(key, Entity.fromJson(entity));
+      }
+    }
+  }
+
+  Map toJson() {
+    return {
+      for (var entry in _references.entries)
+        entry.key: entry.value.map((entity) => entity.toJson()).toList()
+    };
+  }
+}

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+class Cache {
+  final Directory cacheDir = Directory('cache');
+
+  Directory getCreateCacheDirectory(String name) {
+    var dir = Directory(path.join(cacheDir.path, name));
+    if (!dir.existsSync()) {
+      dir.createSync(recursive: true);
+    }
+    return dir;
+  }
+
+  Directory get archivesDir => getCreateCacheDirectory('archives');
+
+  Directory get packagesDir => getCreateCacheDirectory('packages');
+
+  Directory get usageDir => getCreateCacheDirectory('usage');
+}

--- a/lib/packages.dart
+++ b/lib/packages.dart
@@ -72,7 +72,6 @@ class PackageManager {
     var result = await runProcess(
       'tar',
       [
-        // '-xvf',
         '-xf',
         '../../archives/${path.basename(archiveFile.path)}',
       ],

--- a/lib/packages.dart
+++ b/lib/packages.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cli_util/cli_logging.dart';
+import 'package:http/http.dart';
+import 'package:http/retry.dart';
+import 'package:path/path.dart' as path;
+
+import 'cache.dart';
+import 'pub.dart';
+import 'utils.dart';
+
+class PackageManager {
+  final Cache cache = Cache();
+
+  late final Client _client;
+
+  PackageManager() {
+    _client = RetryClient(
+      Client(),
+      when: (response) => const [502, 503].contains(response.statusCode),
+    );
+  }
+
+  // "archive_url":"https://pub.dartlang.org/packages/usage/versions/4.0.2.tar.gz",
+
+  Future<bool> retrievePackageArchive(
+    PackageInfo package, {
+    Logger? logger,
+  }) async {
+    var archiveFile = getArchiveFileForPackage(package);
+
+    if (archiveFile.existsSync()) {
+      return true;
+    }
+
+    var progress =
+        logger?.progress('downloading ${path.basename(archiveFile.path)}');
+    try {
+      Uint8List data = await _getPackageTarGzArchive(package);
+      archiveFile.writeAsBytesSync(data);
+      return true;
+    } finally {
+      progress?.finish(showTiming: true);
+    }
+
+    // This is live as _getPackageTarGzArchive can throw.
+    // ignore: dead_code
+    return false;
+  }
+
+  File getArchiveFileForPackage(PackageInfo package) {
+    var name = '${package.name}-${package.version}.tar.gz';
+    return File(path.join(cache.archivesDir.path, name));
+  }
+
+  Directory getDirectoryForPackage(PackageInfo package) {
+    var name = '${package.name}-${package.version}';
+    return Directory(path.join(cache.packagesDir.path, name));
+  }
+
+  Future<LocalPackage> rehydratePackage(PackageInfo package) async {
+    var archiveFile = getArchiveFileForPackage(package);
+    var localPackage = LocalPackage(package, getDirectoryForPackage(package));
+
+    if (localPackage.directory.existsSync()) {
+      return localPackage;
+    }
+
+    localPackage.directory.createSync(recursive: true);
+
+    var result = await runProcess(
+      'tar',
+      [
+        // '-xvf',
+        '-xf',
+        '../../archives/${path.basename(archiveFile.path)}',
+      ],
+      workingDirectory: localPackage.directory.path,
+    );
+    if (result.exitCode != 0) {
+      print(result.stdout);
+      print(result.stderr);
+    }
+
+    return localPackage;
+  }
+
+  Future<Uint8List> _getPackageTarGzArchive(PackageInfo packageInfo) async {
+    var response = await _client.get(Uri.parse(packageInfo.archiveUrl));
+    if (response.statusCode == 404) {
+      return Future.error(response.reasonPhrase!);
+    }
+    return response.bodyBytes;
+  }
+
+  void close() {
+    _client.close();
+  }
+}
+
+class LocalPackage {
+  final PackageInfo packageInfo;
+  final Directory directory;
+
+  LocalPackage(this.packageInfo, this.directory);
+
+  Future<bool> pubGet({
+    bool checkUpToDate = false,
+    Logger? logger,
+  }) async {
+    if (checkUpToDate) {
+      var pubspec = File(path.join(directory.path, 'pubspec.yaml'));
+      var lock = File(path.join(directory.path, 'pubspec.lock'));
+
+      if (pubspec.existsSync() && lock.existsSync()) {
+        if (!lock.lastModifiedSync().isBefore(pubspec.lastModifiedSync())) {
+          return true;
+        }
+      }
+    }
+
+    final progress = logger?.progress('pub get');
+    var result = await runProcess(
+      Platform.resolvedExecutable,
+      [
+        'pub',
+        'get',
+      ],
+      workingDirectory: directory.path,
+      logger: logger,
+    );
+    progress?.finish(showTiming: true);
+
+    return result.exitCode == 0;
+  }
+}

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -31,7 +31,6 @@ class Pub {
   }
 
   Future<PackageInfo> getPackageInfo(String pkgName) async {
-    //final PackageOptions options = await _getPackageOptions(pkgName);
     final json = await _getJson(Uri.https('pub.dev', 'api/packages/$pkgName'));
 
     return PackageInfo.from(json /*, options: options*/);

--- a/lib/pub.dart
+++ b/lib/pub.dart
@@ -1,0 +1,140 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:http/retry.dart';
+
+typedef PackageFilter = bool Function(PackageInfo packageInfo);
+
+/// Utilities to query pub.dev.
+class Pub {
+  late final Client _client;
+
+  Pub() {
+    _client = RetryClient(
+      Client(),
+      when: (response) => const [502, 503].contains(response.statusCode),
+    );
+  }
+
+  Future<List<PackageInfo>> popularDependenciesOf(
+    String packageName, {
+    int? limit,
+    PackageFilter? filter,
+  }) async {
+    List<PackageInfo> result = await _packagesForSearch(
+      'dependency:$packageName',
+      limit: limit,
+      sort: 'top',
+      filter: filter,
+    ).toList();
+    return result;
+  }
+
+  Future<PackageInfo> getPackageInfo(String pkgName) async {
+    //final PackageOptions options = await _getPackageOptions(pkgName);
+    final json = await _getJson(Uri.https('pub.dev', 'api/packages/$pkgName'));
+
+    return PackageInfo.from(json /*, options: options*/);
+  }
+
+  Stream<PackageInfo> _packagesForSearch(
+    String query, {
+    int page = 1,
+    int? limit,
+    String? sort,
+    PackageFilter? filter,
+  }) async* {
+    final uri = Uri.parse('https://pub.dev/api/search');
+
+    int count = 0;
+
+    for (;;) {
+      final targetUri = uri.replace(queryParameters: {
+        'q': query,
+        'page': page.toString(),
+        if (sort != null) 'sort': sort,
+      });
+
+      final map = await _getJson(targetUri);
+
+      for (var packageName in (map['packages'] as List)
+          .cast<Map<String, dynamic>>()
+          .map((e) => e['package'] as String?)) {
+        var packageInfo = await getPackageInfo(packageName!);
+
+        if (filter == null || filter(packageInfo)) {
+          count++;
+          yield packageInfo;
+        }
+      }
+
+      if (map.containsKey('next')) {
+        page = page + 1;
+      } else {
+        break;
+      }
+
+      if (limit != null && count >= limit) {
+        break;
+      }
+    }
+  }
+
+  Future<Map<String, dynamic>> _getJson(Uri uri) async {
+    final result = await _client.get(uri);
+    if (result.statusCode == 200) {
+      return jsonDecode(result.body) as Map<String, dynamic>;
+    } else {
+      throw StateError('Error getting `$uri` - ${result.statusCode}');
+    }
+  }
+
+  void close() {
+    _client.close();
+  }
+}
+
+class PackageInfo {
+  // {
+  // "name":"usage",
+  // "latest":{
+  //   "version":"4.0.2",
+  //   "pubspec":{
+  //     "name":"usage",
+  //     "version":"4.0.2",
+  //     "description":"A Google Analytics wrapper for command-line, web, and Flutter apps.",
+  //     "repository":"https://github.com/dart-lang/wasm",
+  //     "environment":{
+  //       "sdk":">=2.12.0-0 <3.0.0"
+  //     },
+  //     "dependencies":{
+  //       "path":"^1.8.0"
+  //     },
+  //     "dev_dependencies":{
+  //       "pedantic":"^1.9.0",
+  //       "test":"^1.16.0"
+  //     }
+  //   },
+  //   "archive_url":"https://pub.dartlang.org/packages/usage/versions/4.0.2.tar.gz",
+  //   "published":"2021-03-30T17:44:54.093423Z"
+  // },
+
+  final Map<String, dynamic> json;
+
+  PackageInfo.from(this.json);
+
+  String get name => json['name'];
+  String get description => _pubspec['description'];
+
+  String get version => _latest['version'];
+  String get archiveUrl => _latest['archive_url'];
+  DateTime get publishedDate => DateTime.parse(_published);
+
+  String get _published => _latest['published'];
+
+  late final Map<String, dynamic> _latest = json['latest'];
+  late final Map<String, dynamic> _pubspec = _latest['pubspec'];
+
+  @override
+  String toString() => '$name: $version';
+}

--- a/lib/report.dart
+++ b/lib/report.dart
@@ -1,0 +1,136 @@
+import 'dart:io';
+
+import 'api.dart';
+import 'pub.dart';
+import 'utils.dart';
+
+class Report {
+  final PackageInfo packageInfo;
+
+  Report(this.packageInfo);
+
+  File generateReport(List<ApiUsage> usages, {bool showSrcReferences = false}) {
+    var usage = ApiUsage.combine(packageInfo, usages);
+
+    var file = File('reports/${packageInfo.name}.md');
+    file.parent.createSync();
+    var buf = StringBuffer();
+
+    buf.writeln('# Report for package:${packageInfo.name}');
+    buf.writeln();
+    buf.writeln('## General info');
+    buf.writeln();
+    buf.writeln(packageInfo.description);
+    buf.writeln();
+    buf.writeln('- pub page: https://pub.dev/packages/${packageInfo.name}');
+    buf.writeln(
+        '- docs: https://pub.dev/documentation/${packageInfo.name}/latest/');
+    buf.writeln('- dependent packages: '
+        'https://pub.dev/packages?q=dependency%3A${packageInfo.name}&sort=top');
+    buf.writeln();
+    buf.writeln('Stats for ${packageInfo.name} v${packageInfo.version} pulled '
+        'from ${usage.corpusPackages.length} packages.');
+
+    var packagesReferences = usage.referringPackages;
+    var libraryReferences = usage.referringLibraries;
+
+    // Library references
+    buf.writeln();
+    buf.writeln('## Library references');
+    buf.writeln();
+    buf.writeln('### Library references from packages');
+    buf.writeln();
+    for (var entry in packagesReferences.sortedLibraryReferences.entries) {
+      var val = entry.value;
+      var count = usage.corpusPackages.length;
+      var references = pluralize(val, 'reference');
+      buf.writeln(
+          '- ${entry.key} - $val package $references (${percent(val, count)})');
+      var library = entry.key;
+      if (showSrcReferences && library.contains('/src/')) {
+        for (var entity in packagesReferences.getLibraryReferences(entry.key)) {
+          buf.writeln('  - ${entity.toString()}');
+        }
+      }
+    }
+    buf.writeln();
+    buf.writeln('### Library references from libraries');
+    buf.writeln();
+    for (var entry in libraryReferences.sortedLibraryReferences.entries) {
+      var val = entry.value;
+      var count = libraryReferences.entityCount;
+      var references = pluralize(val, 'reference');
+      buf.writeln(
+          '- ${entry.key} - $val library $references (${percent(val, count)})');
+      var library = entry.key;
+      if (showSrcReferences && library.contains('/src/')) {
+        for (var entity in libraryReferences.getLibraryReferences(entry.key)) {
+          buf.writeln('  - ${entity.toString()}');
+        }
+      }
+    }
+
+    // Class references
+    buf.writeln();
+    buf.writeln('## Class references');
+    buf.writeln();
+    buf.writeln('### Class references from packages');
+    buf.writeln();
+    for (var entry in packagesReferences.sortedClassReferences.entries) {
+      var val = entry.value;
+      var count = usage.corpusPackages.length;
+      var references = pluralize(val, 'reference');
+      buf.writeln(
+          '- ${entry.key} - $val package $references (${percent(val, count)})');
+    }
+    buf.writeln();
+    buf.writeln('### Class references from libraries');
+    buf.writeln();
+    for (var entry in libraryReferences.sortedClassReferences.entries) {
+      var val = entry.value;
+      var count = libraryReferences.entityCount;
+      var references = pluralize(val, 'reference');
+      buf.writeln(
+          '- ${entry.key} - $val library $references (${percent(val, count)})');
+    }
+
+    // Top-level symbols
+    if (packagesReferences.sortedTopLevelReferences.isNotEmpty ||
+        libraryReferences.sortedTopLevelReferences.isNotEmpty) {
+      buf.writeln();
+      buf.writeln('## Top-level symbols');
+      buf.writeln();
+      buf.writeln('### Top-level symbols references from packages');
+      buf.writeln();
+      for (var entry in packagesReferences.sortedTopLevelReferences.entries) {
+        var val = entry.value;
+        var count = usage.corpusPackages.length;
+        var references = pluralize(val, 'reference');
+        buf.writeln(
+            '- ${entry.key} - $val package $references (${percent(val, count)})');
+      }
+      buf.writeln();
+      buf.writeln('### Top-level symbol references from libraries');
+      buf.writeln();
+      for (var entry in libraryReferences.sortedTopLevelReferences.entries) {
+        var val = entry.value;
+        var count = libraryReferences.entityCount;
+        var references = pluralize(val, 'reference');
+        buf.writeln(
+            '- ${entry.key} - $val library $references (${percent(val, count)})');
+      }
+    }
+
+    // Corpus
+    buf.writeln();
+    buf.writeln('## Corpus packages');
+    buf.writeln();
+    for (var package in usage.corpusPackages) {
+      buf.writeln('- ${package.name} v${package.version}');
+    }
+
+    file.writeAsStringSync(buf.toString());
+
+    return file;
+  }
+}

--- a/lib/report.dart
+++ b/lib/report.dart
@@ -34,18 +34,21 @@ class Report {
     var packagesReferences = usage.referringPackages;
     var libraryReferences = usage.referringLibraries;
 
+    // TODO(devoncarew): write a utility class to construct markdown tables;
+    // that could then include automatic whitespace padding for cells
+
     // Library references
     buf.writeln();
     buf.writeln('## Library references');
     buf.writeln();
     buf.writeln('### Library references from packages');
     buf.writeln();
+    buf.writeln('| Library | Package references | % |');
+    buf.writeln('| --- | ---: | ---: |');
     for (var entry in packagesReferences.sortedLibraryReferences.entries) {
       var val = entry.value;
       var count = usage.corpusPackages.length;
-      var references = pluralize(val, 'reference');
-      buf.writeln(
-          '- ${entry.key} - $val package $references (${percent(val, count)})');
+      buf.writeln('| ${entry.key} | $val | ${percent(val, count)} |');
       var library = entry.key;
       if (showSrcReferences && library.contains('/src/')) {
         for (var entity in packagesReferences.getLibraryReferences(entry.key)) {
@@ -56,12 +59,12 @@ class Report {
     buf.writeln();
     buf.writeln('### Library references from libraries');
     buf.writeln();
+    buf.writeln('| Library | Library references | % |');
+    buf.writeln('| --- | ---: | ---: |');
     for (var entry in libraryReferences.sortedLibraryReferences.entries) {
       var val = entry.value;
       var count = libraryReferences.entityCount;
-      var references = pluralize(val, 'reference');
-      buf.writeln(
-          '- ${entry.key} - $val library $references (${percent(val, count)})');
+      buf.writeln('| ${entry.key} | $val | ${percent(val, count)} |');
       var library = entry.key;
       if (showSrcReferences && library.contains('/src/')) {
         for (var entity in libraryReferences.getLibraryReferences(entry.key)) {
@@ -76,22 +79,22 @@ class Report {
     buf.writeln();
     buf.writeln('### Class references from packages');
     buf.writeln();
+    buf.writeln('| Class | Package references | % |');
+    buf.writeln('| --- | ---: | ---: |');
     for (var entry in packagesReferences.sortedClassReferences.entries) {
       var val = entry.value;
       var count = usage.corpusPackages.length;
-      var references = pluralize(val, 'reference');
-      buf.writeln(
-          '- ${entry.key} - $val package $references (${percent(val, count)})');
+      buf.writeln('| ${entry.key} | $val | ${percent(val, count)} |');
     }
     buf.writeln();
     buf.writeln('### Class references from libraries');
     buf.writeln();
+    buf.writeln('| Class | Library references | % |');
+    buf.writeln('| --- | ---: | ---: |');
     for (var entry in libraryReferences.sortedClassReferences.entries) {
       var val = entry.value;
       var count = libraryReferences.entityCount;
-      var references = pluralize(val, 'reference');
-      buf.writeln(
-          '- ${entry.key} - $val library $references (${percent(val, count)})');
+      buf.writeln('| ${entry.key} | $val | ${percent(val, count)} ');
     }
 
     // Top-level symbols
@@ -102,22 +105,22 @@ class Report {
       buf.writeln();
       buf.writeln('### Top-level symbols references from packages');
       buf.writeln();
+      buf.writeln('| Top-level symbol | Package references | % |');
+      buf.writeln('| --- | ---: | ---: |');
       for (var entry in packagesReferences.sortedTopLevelReferences.entries) {
         var val = entry.value;
         var count = usage.corpusPackages.length;
-        var references = pluralize(val, 'reference');
-        buf.writeln(
-            '- ${entry.key} - $val package $references (${percent(val, count)})');
+        buf.writeln('| ${entry.key} | $val | ${percent(val, count)} |');
       }
       buf.writeln();
       buf.writeln('### Top-level symbol references from libraries');
       buf.writeln();
+      buf.writeln('| Top-level symbol | Library references | % |');
+      buf.writeln('| --- | ---: | ---: |');
       for (var entry in libraryReferences.sortedTopLevelReferences.entries) {
         var val = entry.value;
         var count = libraryReferences.entityCount;
-        var references = pluralize(val, 'reference');
-        buf.writeln(
-            '- ${entry.key} - $val library $references (${percent(val, count)})');
+        buf.writeln('| ${entry.key} | $val | ${percent(val, count)} ');
       }
     }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:cli_util/cli_logging.dart';
+
+String percent(int val, int count) {
+  return '${(val * 100 / count).round()}%';
+}
+
+String pluralize(int count, String word, {String? plural}) {
+  return count == 1 ? word : (plural ?? '${word}s');
+}
+
+Future<ProcessResult> runProcess(
+  String executable,
+  List<String> arguments, {
+  String? workingDirectory,
+  bool verbose = false,
+  Logger? logger,
+}) async {
+  if (verbose) {
+    print('$executable ${arguments.join(' ')}');
+  }
+
+  var result = await Process.run(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+  if (result.exitCode != 0) {
+    String out = result.stdout;
+    if (out.isNotEmpty) {
+      logger == null ? print(out.trimRight()) : logger.stdout(out.trimRight());
+    }
+    out = result.stderr;
+    if (out.isNotEmpty) {
+      logger == null ? print(out.trimRight()) : logger.stderr(out.trimRight());
+    }
+  }
+  return result;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,27 @@
+name: corpus
+# or corpus_analyze?
+description: This is a tool to calculate the API usage for a package.
+version: 0.1.0
+publish_to: none
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  analyzer: ^3.4.1
+  args: ^2.0.0
+  cli_util: ^0.3.0
+  http: ^0.13.0
+  path: ^1.8.0
+  surveyor:
+    git:
+      url: https://github.com/pq/surveyor
+
+dev_dependencies:
+  checks:
+    git:
+      url: https://github.com/dart-lang/test
+      path: pkgs/checks
+  lints: '>=1.0.0 <3.0.0'
+  test: ^1.16.0
+  test_descriptor: ^2.0.0

--- a/test/api_test.dart
+++ b/test/api_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:corpus/api.dart';
+import 'package:corpus/pub.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/scaffolding.dart';
+import 'package:test_descriptor/test_descriptor.dart';
+
+void main() {
+  group('ApiUsage', defineApiUsageTests);
+  group('ApiUseCollector', defineApiUseCollectorTests);
+}
+
+void defineApiUsageTests() {
+  late ApiUsage sampleUsage;
+
+  setUp(() {
+    var json = JsonDecoder().convert(_sampleUsageJson);
+    sampleUsage = ApiUsage(
+      PackageInfo.from(JsonDecoder().convert(_packageInfoJson)),
+      References.fromJson(json['packages']),
+      References.fromJson(json['libraries']),
+    );
+  });
+
+  test('toFile', () {
+    var tempFile = File(path.join(sandbox, 'temp.json'));
+    sampleUsage.toFile(tempFile);
+
+    checkThat(tempFile.existsSync()).isTrue();
+
+    // we have a reference to the main package entry-point
+    checkThat(tempFile.readAsStringSync()).contains('package:path/path.dart');
+  });
+
+  test('fromFile', () {
+    var tempFile = File(path.join(sandbox, 'temp.json'));
+    sampleUsage.toFile(tempFile);
+
+    var result = ApiUsage.fromFile(
+        PackageInfo.from(JsonDecoder().convert(_packageInfoJson)), tempFile);
+
+    checkThat(result).isNotNull();
+
+    var fromPackages = result.fromPackages;
+
+    // we have a library reference from package:build
+    checkThat(
+      fromPackages.getLibraryReferences('package:path/path.dart'),
+    ).contains(PackageEntity('build'));
+
+    // there are no references to classes
+    checkThat(fromPackages.sortedClassReferences).isEmpty();
+
+    // there are references to top-level symbols
+    checkThat(fromPackages.sortedTopLevelReferences).isNotEmpty();
+
+    var fromLibraries = result.fromLibraries;
+
+    // we have a library reference from package:build
+    checkThat(
+      fromLibraries.getLibraryReferences('package:path/path.dart'),
+    ).isNotEmpty();
+
+    // there are no references to classes
+    checkThat(fromLibraries.sortedClassReferences).isEmpty();
+
+    // there are references to top-level symbols
+    checkThat(fromLibraries.sortedTopLevelReferences).isNotEmpty();
+  });
+}
+
+void defineApiUseCollectorTests() {
+  // todo: test ApiUseCollector; we need a test for each of
+  // - finding libraries references
+  // - finding class references
+  // - finding top-level symbol references
+}
+
+const String _sampleUsageJson = '''
+{
+  "packages": {
+    "library": {
+      "package:path/path.dart": [
+        "package:build"
+      ]
+    },
+    "class": {},
+    "topLevel": {
+      "url": [
+        "package:build"
+      ],
+      "posix": [
+        "package:build"
+      ]
+    }
+  },
+  "libraries": {
+    "library": {
+      "package:path/path.dart": [
+        "library:build:lib/src/asset/id.dart"
+      ]
+    },
+    "class": {},
+    "topLevel": {
+      "url": [
+        "library:build:lib/src/asset/id.dart"
+      ],
+      "posix": [
+        "library:build:lib/src/asset/id.dart"
+      ]
+    }
+  }
+}
+''';
+
+final String _packageInfoJson = '''
+{
+  "name": "path",
+  "latest": {
+    "version": "1.8.2",
+    "pubspec": {
+      "name": "path",
+      "version": "1.8.2",
+      "description": "A string-based path manipulation library.",
+      "repository": "https://github.com/dart-lang/path",
+      "environment": {
+        "sdk": ">=2.12.0 <3.0.0"
+      }
+    },
+    "archive_url": "https://pub.dartlang.org/packages/path/versions/1.8.2.tar.gz",
+    "published": "2021-03-30T17:44:54.093423Z"
+  }
+}
+''';

--- a/test/pub_test.dart
+++ b/test/pub_test.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+
+import 'package:checks/checks.dart';
+import 'package:corpus/pub.dart';
+import 'package:test/scaffolding.dart';
+
+void main() {
+  group('PackageInfo', definePackageInfoTests);
+}
+
+void definePackageInfoTests() {
+  test('parse pub.dev results', () {
+    var packageInfo = PackageInfo.from(jsonDecode(_pubSampleData));
+
+    checkThat(packageInfo.name).equals('usage');
+    checkThat(packageInfo.version).equals('4.0.2');
+    checkThat(packageInfo.archiveUrl).isNotNull();
+    checkThat(packageInfo.publishedDate).isNotNull();
+  });
+}
+
+final String _pubSampleData = '''
+{
+  "name": "usage",
+  "latest": {
+    "version": "4.0.2",
+    "pubspec": {
+      "name": "usage",
+      "version": "4.0.2",
+      "description": "A Google Analytics wrapper for command-line, web, and Flutter apps.",
+      "repository": "https://github.com/dart-lang/wasm",
+      "environment": {
+        "sdk":">=2.12.0-0 <3.0.0"
+      },
+      "dependencies": {
+        "path":"^1.8.0"
+      },
+      "dev_dependencies": {
+        "pedantic":"^1.9.0",
+        "test":"^1.16.0"
+      }
+    },
+    "archive_url": "https://pub.dartlang.org/packages/usage/versions/4.0.2.tar.gz",
+    "published": "2021-03-30T17:44:54.093423Z"
+  }
+}
+''';


### PR DESCRIPTION
Initial PR for a package API usage analysis tool. From the readme:

> This is a tool to calculate the API usage for a package - what part's of a package's API are typically used by other Dart packages and applications.

This works by:
- querying pub for references to a given package
- downloading each referencing package (as a tar.gz file)
- uncompressing that package into a cache dir
- running 'pub get' in that directory
- using `package:surveyor` to visit the resolved ASTs of the package
- collecting references to the target package (the package's library files, classes, or top-level symbols)
- combining that information - for all the n referencing packages - into a report of general API usage info

Some notes for reviewers:
- I do plan to move this into the dart-lang/ github org in the ~near term
- thoughts on the package name are appreciated (currently `corpus`, though I believe that could be overloaded; I also considered `corpus_analysis`)
- the analyzer AST usage and traversal code is on `lib/api.dart`
- I'm happy to break this into separate PRs for easier review, comment files out for an initial review, push individual files to separate PRs, ...
